### PR TITLE
feat: sync all stats

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: ${DB_NAME}
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - db_data:/var/lib/mysql
 

--- a/src/modules/teams/dto/get-team-stats.dto.ts
+++ b/src/modules/teams/dto/get-team-stats.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, IsNotEmpty, IsInt, Min } from 'class-validator';
-import { Type } from 'class-transformer'; // <--- Важный импорт
+import { Type } from 'class-transformer';
 
 export class GetTeamStatsDto {
   @IsString({ message: 'teamId должен быть строкой' })
@@ -13,5 +13,5 @@ export class GetTeamStatsDto {
   @Type(() => Number)
   @IsInt({ message: 'season должен быть числом' })
   @Min(2000)
-  season!: number;
+  season!: string;
 }

--- a/src/modules/teams/teams.controller.ts
+++ b/src/modules/teams/teams.controller.ts
@@ -65,6 +65,14 @@ router.post(
   },
 );
 
+router.post('/teams/sync-all-stats', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await teamsService.syncAllTeamStatistics();
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
 /**
  * POST /teams
  * Создает новую команду


### PR DESCRIPTION
## 🚀 Summary
Implemented a mechanism to synchronize statistics for **all** teams in the database that have valid external IDs.

## 🛠️ Changes
- **API:** Added `POST /teams/sync-all-stats` endpoint.
- **Service:** Implemented `syncAllTeamStatistics` logic:
  - Fetches all teams from DB.
  - Filters teams with valid `external_team_id` and `sport_id`.
  - Uses `Promise.allSettled` to process requests in parallel without blocking on errors.