### PR TITLE
Feat/nhl stats

### DIFF
--- a/migrations/20260203130243_create_nhl_stats_table.ts
+++ b/migrations/20260203130243_create_nhl_stats_table.ts
@@ -1,0 +1,17 @@
+import type { Knex } from 'knex';
+
+const tableName = 'nhl_stats';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.createTable(tableName, (table) => {
+    table.increments('id').primary();
+    table.integer('goals_Islanders').notNullable();
+    table.integer('goals_Enemy').notNullable();
+    table.boolean('are_we_happy').notNullable();
+    table.string('game_date').notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTableIfExists(tableName);
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,8 +6,7 @@ import { errorHandler } from './common/middleware/error-handler';
 
 const app = express();
 
-// Включаем парсинг JSON-запросов
-app.use(express.json()); // <-- добавлено для поддержки методов POST/PATCH/PUT
+app.use(express.json());
 
 const PORT = 3000;
 app.use('/api', teamsRouter);

--- a/src/common/constants/season.ts
+++ b/src/common/constants/season.ts
@@ -1,0 +1,1 @@
+export const CURRENT_SEASON = 2024;

--- a/src/common/errors/http-error.ts
+++ b/src/common/errors/http-error.ts
@@ -1,9 +1,9 @@
 export class HttpError extends Error {
-    status: number;
-  
-    constructor(status: number, message: string) {
-      super(message);
-      this.status = status;
-      Object.setPrototypeOf(this, HttpError.prototype);
-    }
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    Object.setPrototypeOf(this, HttpError.prototype);
   }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export const config = {
   externalApi: {
     url: getEnvVar('EXTERNAL_FOOTBALL_API_URL'),
     secondaryUrl: getEnvVar('EXTERNAL_BASKETBALL_API_URL'),
+    nhlApiUrl: getEnvVar('EXTERNAL_HOCKEY_API_URL'),
     key: getEnvVar('EXTERNAL_API_KEY'),
   },
 };

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,8 +1,9 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { HealthService } from './health.service';
 import { TeamStatsRepository } from '../../repositories/TeamStatsRepository';
+import db from '../../common/db/database';
 
-const teamStatsRepository = new TeamStatsRepository();
+const teamStatsRepository = new TeamStatsRepository(db);
 const healthService = new HealthService(teamStatsRepository);
 const router = Router();
 

--- a/src/modules/teams/dto/external-nhl-results.dto.ts
+++ b/src/modules/teams/dto/external-nhl-results.dto.ts
@@ -1,0 +1,106 @@
+// 1. Вспомогательные типы для локализации (default, fr, es...)
+export interface NhlLocalizedName {
+  default: string;
+  fr?: string;
+  es?: string;
+  cs?: string;
+  fi?: string;
+  sk?: string;
+  sv?: string;
+}
+
+// 2. Информация о трансляции
+export interface NhlTvBroadcast {
+  id: number;
+  market: string; // "A" (Away), "H" (Home), "N" (National)
+  countryCode: string;
+  network: string;
+  sequenceNumber: number;
+}
+
+// 3. Информация о месте проведения
+export type NhlVenue = NhlLocalizedName;
+
+// 4. Информация об игроке (вратарь/скорер)
+export interface NhlPlayer {
+  playerId: number;
+  firstInitial: NhlLocalizedName;
+  lastName: NhlLocalizedName;
+}
+
+// 5. Команда (Away/Home)
+export interface NhlTeamInfo {
+  id: number;
+  commonName: NhlLocalizedName;
+  placeName: NhlLocalizedName;
+  placeNameWithPreposition: NhlLocalizedName;
+  abbrev: string;
+  logo: string;
+  darkLogo: string;
+  score?: number; // Опционально, т.к. игра может быть не начата
+  radioLink?: string;
+  // Специфичные поля для home/away
+  awaySplitSquad?: boolean;
+  homeSplitSquad?: boolean;
+}
+
+// 6. Описание периода
+export interface NhlPeriodDescriptor {
+  number: number;
+  periodType: string; // "REG", "OT", "SO"
+  maxRegulationPeriods: number;
+}
+
+// 7. Сама ИГРА 🏒
+export interface NhlGame {
+  id: number;
+  season: number;
+  gameType: number;
+  venue: NhlVenue;
+  neutralSite: boolean;
+  startTimeUTC: string; // ISO Date "2026-01-07T00:00:00Z"
+  easternUTCOffset: string;
+  venueUTCOffset: string;
+  venueTimezone: string;
+  gameState: string; // "OFF" (Official/Final), "FUT" (Future), "LIVE"
+  gameScheduleState: string; // "OK"
+  tvBroadcasts: NhlTvBroadcast[];
+  awayTeam: NhlTeamInfo;
+  homeTeam: NhlTeamInfo;
+  periodDescriptor: NhlPeriodDescriptor;
+
+  // Поля, которые появляются после окончания игры
+  gameOutcome?: {
+    lastPeriodType: string;
+  };
+  winningGoalie?: NhlPlayer;
+  winningGoalScorer?: NhlPlayer;
+
+  // Ссылки на видео
+  threeMinRecap?: string;
+  threeMinRecapFr?: string;
+  condensedGame?: string;
+  condensedGameFr?: string;
+  gameCenterLink: string;
+}
+
+// 8. День недели (Группировка игр по датам)
+export interface NhlGameWeekDay {
+  date: string; // "2026-01-06"
+  dayAbbrev: string; // "TUE"
+  numberOfGames: number;
+  datePromo?: unknown[]; // Обычно пустой массив, можно оставить any[]
+  games: NhlGame[];
+}
+
+// 9. 🚀 ГЛАВНЫЙ DTO ОТВЕТА
+export interface ExternalNhlResultsDto {
+  nextStartDate: string;
+  previousStartDate: string;
+  preSeasonStartDate: string;
+  regularSeasonStartDate: string;
+  regularSeasonEndDate: string;
+  playoffEndDate: string;
+  numberOfGames: number;
+  gameWeek: NhlGameWeekDay[];
+}

--- a/src/modules/teams/dto/get-team-stats.dto.ts
+++ b/src/modules/teams/dto/get-team-stats.dto.ts
@@ -13,5 +13,5 @@ export class GetTeamStatsDto {
   @Type(() => Number)
   @IsInt({ message: 'season должен быть числом' })
   @Min(2000)
-  season!: string;
+  season!: number;
 }

--- a/src/modules/teams/dto/nhl-results.dto.ts
+++ b/src/modules/teams/dto/nhl-results.dto.ts
@@ -2,4 +2,5 @@ export class NhlResultsDto {
   goals_Islanders!: number;
   goals_Enemy!: number;
   are_we_happy!: boolean;
+  game_date!: string;
 }

--- a/src/modules/teams/dto/nhl-results.dto.ts
+++ b/src/modules/teams/dto/nhl-results.dto.ts
@@ -1,0 +1,5 @@
+export class NhlResultsDto {
+  goals_Islanders!: number;
+  goals_Enemy!: number;
+  are_we_happy!: boolean;
+}

--- a/src/modules/teams/mappers/nhl-results-mapper.ts
+++ b/src/modules/teams/mappers/nhl-results-mapper.ts
@@ -36,5 +36,6 @@ export const mapNhlResults = (
     goals_Islanders: goalsIslanders,
     goals_Enemy: goalsEnemy,
     are_we_happy: goalsIslanders > goalsEnemy,
+    game_date: targetDate,
   };
 };

--- a/src/modules/teams/mappers/nhl-results-mapper.ts
+++ b/src/modules/teams/mappers/nhl-results-mapper.ts
@@ -1,0 +1,40 @@
+import { ExternalNhlResultsDto } from '../dto/external-nhl-results.dto';
+import { NhlResultsDto } from '../dto/nhl-results.dto';
+
+const TARGET_TEAM = 'Islanders';
+
+export const mapNhlResults = (
+  externalData: ExternalNhlResultsDto,
+  targetDate: string,
+): NhlResultsDto | null => {
+  const dayStats = externalData.gameWeek.find((day) => day.date === targetDate);
+  if (!dayStats) return null;
+
+  const targetGame = dayStats.games.find(
+    (game) =>
+      game.homeTeam.commonName.default === TARGET_TEAM ||
+      game.awayTeam.commonName.default === TARGET_TEAM,
+  );
+
+  if (!targetGame) return null;
+  if (targetGame.gameState !== 'OFF' && targetGame.gameState !== 'FINAL') {
+    return null;
+  }
+
+  let goalsIslanders = 0;
+  let goalsEnemy = 0;
+
+  if (targetGame.homeTeam.commonName.default === TARGET_TEAM) {
+    goalsIslanders = targetGame.homeTeam.score ?? 0;
+    goalsEnemy = targetGame.awayTeam.score ?? 0;
+  } else {
+    goalsIslanders = targetGame.awayTeam.score ?? 0;
+    goalsEnemy = targetGame.homeTeam.score ?? 0;
+  }
+
+  return {
+    goals_Islanders: goalsIslanders,
+    goals_Enemy: goalsEnemy,
+    are_we_happy: goalsIslanders > goalsEnemy,
+  };
+};

--- a/src/modules/teams/providers/nhl-api.gateway.ts
+++ b/src/modules/teams/providers/nhl-api.gateway.ts
@@ -1,0 +1,44 @@
+import axios, { AxiosInstance } from 'axios';
+import { config } from '../../../config';
+import { ExternalNhlResultsDto } from '../dto/external-nhl-results.dto';
+import { HttpError } from '../../../common/errors/http-error';
+
+export class NhlApiGateway {
+  private readonly client: AxiosInstance;
+
+  constructor() {
+    this.client = axios.create({
+      baseURL: config.externalApi.nhlApiUrl,
+      timeout: 30000,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+  async getNhlResultsForDate(): Promise<ExternalNhlResultsDto> {
+    const date = '2026-01-06';
+    const url = `schedule/${date}`;
+    try {
+      const { data } = await this.client.get<ExternalNhlResultsDto>(url);
+      return data;
+    } catch (error) {
+      this.handleError(error);
+      throw error;
+    }
+  }
+  private handleError(error: unknown): void {
+    if (error instanceof Error) {
+      console.log('Error Name:', error.name);
+      console.log('Error Message:', error.message);
+      console.log('Error Stack:', error.stack);
+    } else {
+      console.log('Raw Error:', error);
+    }
+    console.log('--- DEBUG ERROR END ---');
+
+    if (axios.isAxiosError(error)) {
+      console.error('[NHL API] Unexpected SYSTEM error:', error);
+      throw new HttpError(500, `Internal Server Error in NHL Gateway: ${(error as Error).message}`);
+    }
+  }
+}

--- a/src/modules/teams/teams.service.ts
+++ b/src/modules/teams/teams.service.ts
@@ -16,6 +16,7 @@ import { BasketballStatsMapper } from './mappers/basketball-team-stats.mapper';
 import { mapNhlResults } from './mappers/nhl-results-mapper';
 import { GetTeamStatsDto } from './dto/get-team-stats.dto';
 import { SaveTeamStatsDto } from './dto/save-team-stats.dto';
+import { CURRENT_SEASON } from '../../common/constants/season';
 
 export class TeamsService {
   constructor(
@@ -124,19 +125,13 @@ export class TeamsService {
 
     if (!statDto) {
       console.log(`[Service] Результат за ${TARGET_DATE} не найден.`);
+      return null;
     }
+    await this.teamsStatRepository.saveNhlStatistics(statDto);
     return statDto;
   }
   async syncAllTeamStatistics() {
     const findTeams = await this.teamsRepository.findAll();
-    // 👇 ДОБАВЬ ЭТО
-    if (findTeams.length > 0) {
-      console.log('🔍 ПРОВЕРКА ПОЛЕЙ:', Object.keys(findTeams[0]));
-      console.log('📄 ДАННЫЕ:', findTeams[0]);
-    } else {
-      console.log('❌ findAll вернул пустой массив!');
-    }
-    // 👆
     const syncableTeams = findTeams.filter(
       (team) => team.external_team_id && team.external_league_id && team.sport_id,
     );
@@ -146,7 +141,7 @@ export class TeamsService {
         const params: GetTeamStatsDto = {
           leagueId: team.external_league_id!.toString(),
           teamId: team.external_team_id!.toString(),
-          season: '2023',
+          season: CURRENT_SEASON,
         };
 
         if (team.sport_id === 1) {

--- a/src/repositories/TeamRepository.ts
+++ b/src/repositories/TeamRepository.ts
@@ -1,9 +1,10 @@
-import db from '../common/db/database';
+import { Knex } from 'knex';
 import { CreateTeamDto, UpdateTeamDto, PatchTeamDto } from '../modules/teams/dto';
 
 export class TeamRepository {
+  constructor(private readonly db: Knex = db) {}
   async findAll() {
-    return db('teams as t')
+    return this.db('teams as t')
       .join('countries as c', 't.country_id', 'c.id')
       .join('sports as s', 't.sport_id', 's.id')
       .select(
@@ -18,29 +19,29 @@ export class TeamRepository {
   }
 
   async create(dto: CreateTeamDto): Promise<number> {
-    const [id] = await db('teams').insert(dto);
+    const [id] = await this.db('teams').insert(dto);
     return id;
   }
 
   async update(id: number, dto: UpdateTeamDto): Promise<boolean> {
-    const affectedRows = await db('teams').where({ id }).update(dto);
+    const affectedRows = await this.db('teams').where({ id }).update(dto);
 
     return affectedRows > 0;
   }
 
   async patch(id: number, dto: PatchTeamDto): Promise<boolean> {
-    const affectedRows = await db('teams').where({ id }).update(dto);
+    const affectedRows = await this.db('teams').where({ id }).update(dto);
 
     return affectedRows > 0;
   }
 
   async delete(id: number): Promise<boolean> {
-    const affectedRows = await db('teams').where({ id }).delete();
+    const affectedRows = await this.db('teams').where({ id }).delete();
 
     return affectedRows > 0;
   }
 
   async findById(id: number) {
-    return db('teams').where({ id }).first();
+    return this.db('teams').where({ id }).first();
   }
 }

--- a/src/repositories/TeamStatsRepository.ts
+++ b/src/repositories/TeamStatsRepository.ts
@@ -1,8 +1,25 @@
 import { Knex } from 'knex';
 import { SaveTeamStatsDto } from '../modules/teams/dto';
+import { NhlResultsDto } from '../modules/teams/dto/nhl-results.dto';
 
 export class TeamStatsRepository {
   constructor(private readonly db: Knex) {}
+
+  async saveNhlStatistics(stats: NhlResultsDto): Promise<void> {
+    const sql = `
+      INSERT INTO nhl_stats
+        (goals_Islanders, goals_Enemy, are_we_happy, game_date)
+      VALUES 
+        (?, ?, ?, ?)`;
+
+    await this.db.raw(sql, [
+      stats.goals_Islanders,
+      stats.goals_Enemy,
+      stats.are_we_happy,
+      stats.game_date,
+    ]);
+  }
+
   async saveTeamStatistics(stats: SaveTeamStatsDto): Promise<void> {
     const sql = `
       INSERT INTO team_statistics 

--- a/src/repositories/TeamStatsRepository.ts
+++ b/src/repositories/TeamStatsRepository.ts
@@ -1,7 +1,8 @@
-import db from '../common/db/database';
+import { Knex } from 'knex';
 import { SaveTeamStatsDto } from '../modules/teams/dto';
 
 export class TeamStatsRepository {
+  constructor(private readonly db: Knex) {}
   async saveTeamStatistics(stats: SaveTeamStatsDto): Promise<void> {
     const sql = `
       INSERT INTO team_statistics 
@@ -15,7 +16,7 @@ export class TeamStatsRepository {
         created_at = CURRENT_TIMESTAMP
     `;
 
-    await db.raw(sql, [
+    await this.db.raw(sql, [
       stats.external_team_id,
       stats.external_league_id,
       stats.season,
@@ -26,7 +27,7 @@ export class TeamStatsRepository {
   }
   async healthCheck(): Promise<boolean> {
     try {
-      await db.raw('SELECT 1');
+      await this.db.raw('SELECT 1');
       return true;
     } catch {
       return false;


### PR DESCRIPTION
# Title: feat: Implement NHL stats synchronization and storage

## 📝 Description
This PR implements the functionality to fetch NHL game results from an external API, process the data, and save statistics (specifically for the Islanders) into the database. It also includes architectural refactorings to support Dependency Injection.

## 🚀 Key Changes

### 🏗 Architecture & Refactoring
- **TeamsService**: Refactored to use **Dependency Injection**. Dependencies (`TeamRepository`, `TeamStatsRepository`, Gateways) are now injected via constructor instead of being instantiated inside the class.
- **TeamsController**: Updated to manually assemble dependencies and inject them into the service.

### 🔌 API & Logic
- **NhlApiGateway**: Added a new gateway to fetch schedule data from the external NHL API.
- **Mapper**: Implemented `mapNhlResults` to parse external data into `NhlResultsDto`.
- **Service Logic**: Updated `getNhlTeamResult` to fetch data and save it to the DB if a game result is found.

### 💾 Database (Knex)
- **Migration**: Added a new migration file to create the `nhl_stats` table.
- **Repository**: Added `saveNhlStatistics` method to `TeamStatsRepository` to insert game results using raw SQL.