### PR TITLE
feat: nhl-stats-refactor

### DIFF
--- a/src/common/constants/nhl-target-team.ts
+++ b/src/common/constants/nhl-target-team.ts
@@ -1,0 +1,1 @@
+export const TARGET_TEAM_NHL = 'Islanders';

--- a/src/modules/teams/dto/nhl-results.dto.ts
+++ b/src/modules/teams/dto/nhl-results.dto.ts
@@ -4,3 +4,8 @@ export class NhlResultsDto {
   are_we_happy!: boolean;
   game_date!: string;
 }
+
+export type NhlMappingResult =
+  | { status: 'SUCCESS'; data: NhlResultsDto }
+  | { status: 'RETRY'; newTargetDate: string }
+  | { status: 'NOT_FOUND' };

--- a/src/modules/teams/providers/nhl-api.gateway.ts
+++ b/src/modules/teams/providers/nhl-api.gateway.ts
@@ -15,8 +15,7 @@ export class NhlApiGateway {
       },
     });
   }
-  async getNhlResultsForDate(): Promise<ExternalNhlResultsDto> {
-    const date = '2026-01-06';
+  async getNhlResultsForWeek(date: string): Promise<ExternalNhlResultsDto> {
     const url = `schedule/${date}`;
     try {
       const { data } = await this.client.get<ExternalNhlResultsDto>(url);


### PR DESCRIPTION
## 📝 Summary
Implemented a **Smart Polling** mechanism for NHL stats. Instead of failing when no games are found for the current week, the service now automatically retries using the `previousStartDate` provided by the API (recursive fetch up to 5 attempts).

## 🛠 Key Changes
- **Service (`teams.service.ts`):** Replaced linear logic with a `while` loop to handle retries.
- **Gateway (`nhl.gateway.ts`):** Parameterized `getNhlResultsForWeek` to accept dynamic dates (fixed `Date` class bug).
- **Mapper (`nhl-results.mapper.ts`):**
    - Introduced `NhlMappingResult` (`SUCCESS` | `RETRY` | `NOT_FOUND`).
    - Added logic to return `previousStartDate` if the current week is empty.
    - Added sorting to always pick the most recent completed game.